### PR TITLE
Update ADBMobileConfig.json

### DIFF
--- a/assets/ADBMobileConfig.json
+++ b/assets/ADBMobileConfig.json
@@ -6,7 +6,7 @@
   "analytics": {
     "rsids": "",
     "server": "",
-    "ssl": false,
+    "ssl": true,
     "offlineEnabled": true,
     "charset": "UTF-8",
     "lifecycleTimeout": 300,


### PR DESCRIPTION
Changing ssl to true, so that by default Adobe analytics uses SSL. I understand this is just an example but people have tendency to use an example in their projects so better to make this example 'secure by default'.